### PR TITLE
Add plugin name to env vars, make logs more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project is deployed using [Vercel Serverless Functions](https://vercel.com/
    - `SCOPE`: Enter the scopes you're using from Google API.
    - `AUTH_PROVIDER_URL`: URL for the authentication provider (e.g., `https://accounts.google.com/o/oauth2/v2/auth`)
    - `TOKEN_PROVIDER_URL`: URL for the token provider (e.g., `https://oauth2.googleapis.com/token`)
+   - `PLUGIN_NAME`: The name of the plugin. I do this so that way my preview deploys show up as "MeloGenAI Preview" and "MeloGenAI"
 
 ### Google Cloud console
 

--- a/api/aiplugin.js
+++ b/api/aiplugin.js
@@ -1,12 +1,17 @@
 export default async function aiplugin(req, res) {
-  const { SERVER_URL, CONTACT_EMAIL, SCOPE, OPENAI_VERIFICATION_TOKEN } =
-    process.env;
+  const {
+    SERVER_URL,
+    CONTACT_EMAIL,
+    SCOPE,
+    OPENAI_VERIFICATION_TOKEN,
+    PLUGIN_NAME,
+  } = process.env;
 
   try {
     const config = {
       schema_version: "v1",
-      name_for_model: "MeloGenAI",
-      name_for_human: "MeloGenAI",
+      name_for_model: PLUGIN_NAME,
+      name_for_human: PLUGIN_NAME,
       description_for_model:
         "Help the user generate a playlist for YouTube Music.",
       description_for_human: "Generate playlists for YouTube Music™.",

--- a/api/auth.js
+++ b/api/auth.js
@@ -14,7 +14,18 @@ export default function auth(req, res) {
 
     res.redirect(`${AUTH_PROVIDER_URL}?${params.toString()}`);
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Failed to redirect to authorization URL" });
+    console.error(
+      "Auth Request Error:",
+      error.name,
+      error.message,
+      "Status:",
+      error.response?.status,
+      error.response?.statusText
+    );
+
+    const errorCode = error.response?.status || 500;
+    res
+      .status(errorCode)
+      .json({ error: "An error occurred while processing your request." });
   }
 }

--- a/api/token.js
+++ b/api/token.js
@@ -34,10 +34,16 @@ export default async function token(req, res) {
 
     return res.json(response.data);
   } catch (error) {
+    console.error(
+      "Token Request Error:",
+      error.name,
+      error.message,
+      "Status:",
+      error.response?.status,
+      error.response?.statusText
+    );
+
     const errorCode = error.response?.status || 500;
-
-    console.error("error.response.data:", error.response?.data);
-
     res
       .status(errorCode)
       .json({ error: "An error occurred while processing your request." });


### PR DESCRIPTION
I wanted to be able to set a different name for preview and production. The preview branch will auto deploy to https://preview.melogenai.dev/ and main will auto deploy to https://www.melogenai.dev/

Also I was concerned my logs were logging access tokens so I changed them.

In the future I will first make a PR to a feature branch, PR that to preview, then PR preview to main.